### PR TITLE
fix(windows): Add new sdk version to sign tool on Windows Server 2025

### DIFF
--- a/Sign-File.ps1
+++ b/Sign-File.ps1
@@ -19,7 +19,7 @@ function FindSignTool {
     if (Test-Path -Path $SignTool -PathType Leaf) {
         return $SignTool
     }
-    $sdkVers = "10.0.22000.0", "10.0.20348.0", "10.0.19041.0", "10.0.17763.0"
+    $sdkVers = "10.0.26100.0", "10.0.22000.0", "10.0.20348.0", "10.0.19041.0", "10.0.17763.0"
     Foreach ($ver in $sdkVers)
     {
         $SignTool = "${env:ProgramFiles(x86)}\Windows Kits\10\bin\${ver}\x64\signtool.exe"


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

Add a new version of the SDK that is shipped with the new Windows Server 2025.

## Related

Failed job in esptool: https://github.com/espressif/esptool/actions/runs/17459071654/job/49579324684

## Testing

Passing pipeline: TODO

