### PR TITLE
fix: restrict binary signing to espressif org push events only

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ If you would like to sign Windows binaries, you can configure Azure Key Vault cr
 
 The action uses the [espressif/release-sign](https://github.com/espressif/release-sign) action internally, which requires Azure credentials to access a certificate stored in Azure Key Vault. If the Azure client secret is not set, signing will be skipped with a warning message.
 
+> [!NOTE]
+> Signing only runs on `push` and `release` events within the `espressif` GitHub organization. Pull request builds will compile and test the binary but skip signing, even if Azure credentials are provided. This ensures only reviewed and merged code is signed.
+
 To enable signing, you must explicitly pass the Azure credentials as inputs from your workflow. Set the following secrets in your repository and pass them to the action:
 
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -262,14 +262,16 @@ runs:
 
     - name: Check signing certificate
       if: |
-        inputs.target-platform == 'windows-amd64' && inputs.azure-client-secret == ''
+        inputs.target-platform == 'windows-amd64' && inputs.azure-client-secret == '' &&
+        (github.event_name == 'push' || github.event_name == 'release') && github.repository_owner == 'espressif'
       shell: pwsh
       run: |
         Write-Host "::warning title=Signing::Azure client secret is not set, skipping signing"
 
     - name: Sign binaries
       if: |
-        inputs.target-platform == 'windows-amd64' && inputs.azure-client-secret != ''
+        inputs.target-platform == 'windows-amd64' && inputs.azure-client-secret != '' &&
+        (github.event_name == 'push' || github.event_name == 'release') && github.repository_owner == 'espressif'
       uses: espressif/release-sign@master
       with:
         path: ${{ inputs.output-dir }}
@@ -281,6 +283,7 @@ runs:
 
     - name: Remove leftover signature files
       if: |
-        inputs.target-platform == 'windows-amd64' && inputs.azure-client-secret != ''
+        inputs.target-platform == 'windows-amd64' && inputs.azure-client-secret != '' &&
+        (github.event_name == 'push' || github.event_name == 'release') && github.repository_owner == 'espressif'
       shell: bash
       run: find ./${{ inputs.output-dir }} -name "*.sig" -type f -delete


### PR DESCRIPTION
## Description

Signing was running on all builds including PRs. Since secrets are accessible on internal PRs, unreviewed code could be signed before merge. Now signing only runs on push events in the espressif org, ensuring only merged code gets signed.

## Related
Internal tracker: IDF-15184