### PR TITLE
fix: Build cryptography from source for ARMv7 binaries

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -169,6 +169,8 @@ runs:
     - name: Build for ARMv7 architecture
       if: inputs.target-platform == 'linux-armv7'
       shell: bash
+      # Force `cryptography` to build from sdist on ARMv7: the published
+      # manylinux_2_31_armv7l wheel ships an OpenSSL mismatch.
       run: |
         docker run --rm \
           --platform linux/arm/v7 \
@@ -195,7 +197,7 @@ runs:
           /github/action/setup_environment.sh \
             '${{ inputs.pyinstaller-version }}' \
             '${{ inputs.pip-extra-index-url }}' \
-            '${{ inputs.install-deps-command }}' &&
+            '${{ inputs.install-deps-command }} --no-binary cryptography' &&
 
           /github/action/build_with_pyinstaller.sh '${{ inputs.target-platform }}' '${{ inputs.output-dir }}' '${{ inputs.scripts }}' '${{ inputs.script-name }}' '${{ inputs.icon-file }}' '/github/action/include_data_dirs.json' '${{ steps.setup-platform.outputs.data-separator }}' '${{ inputs.additional-args }}' &&
 


### PR DESCRIPTION
## Problem

The `Build esptool binaries for linux-armv7` job (and any consumer of this action with `target-platform: linux-armv7`) crashes at runtime because the PyInstaller-bundled `cryptography` cannot import:

```
ImportError: cryptography.libs/libcrypto-…so.3: version `OPENSSL_3.2.0' not found
  (required by cryptography/hazmat/bindings/_rust.abi3.so)
```

Example failure: https://github.com/espressif/esptool/actions/runs/26216378342/job/77336785777

## Root cause

The published `cryptography==48.0.0` `manylinux_2_31_armv7l` wheel ships a bundled `libcrypto-…so.3` that does not export the versioned OpenSSL symbols (`OPENSSL_3.2.0`, `OPENSSL_3.3.0`) its companion `_rust.abi3.so` requires. Other platforms get different wheel variants and are unaffected.

## Fix

In the ARMv7 docker step, append `--no-binary cryptography` to the `install-deps-command` passed to `setup_environment.sh`. `uv` then builds `cryptography` from sdist against the container's `libssl-dev` (already preinstalled in `idf-python-wheels-armv7l:v1`), producing a binding linked against a consistent OpenSSL.

Single-line change in `action.yml`; no input or interface changes.

## Verification

Downstream esptool build with this action revision: **all 6 platforms green**, including `linux-armv7`:

https://github.com/dobairoland/esptool/actions/runs/26281714135

ARMv7 job (~29 min — sdist build accounts for the extra time): https://github.com/dobairoland/esptool/actions/runs/26281714135/job/77362100143