### PR TITLE
fix: Use full version of setup-uv action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -251,7 +251,7 @@ runs:
     - name: Install UV
       if: |
         steps.setup-platform.outputs.needs-docker == 'false' && steps.setup-platform.outputs.needs-arm-emulation == 'false'
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
 


### PR DESCRIPTION
Uv decided to stop using `v8` branches that get regularly updated with new minor and patch releases, now you need to set the full action version, see:  https://github.com/astral-sh/setup-uv/issues/830

Failing pipeline: https://github.com/peterdragun/esptool/actions/runs/26291156716/job/77396684064