### PR TITLE
Fixed Python.framework different Team IDs - MacOS signing issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,11 @@ To enable signing, you must explicitly pass the Azure credentials as inputs from
 
 For `macos-amd64` and `macos-arm64` builds on macOS runners, you can sign and optionally notarize binaries using the same [espressif/release-sign](https://github.com/espressif/release-sign) action. If the macOS certificate is not set, signing will be skipped with a warning message.
 
-**Notarization** runs only on tag pushes (for example `v5.2.0`). Branch pushes and pull requests are still **signed** when credentials are provided, but notarization credentials are not passed to `release-sign`.
+**One-file binaries** must be signed during the PyInstaller build (`--codesign-identity`), not only afterward. On eligible `push` and `release` events within the `espressif` organization, this action imports the Developer ID certificate before PyInstaller runs so embedded libraries and the bootloader share the same Team ID. The outer binary is then re-signed and optionally notarized by `release-sign`. A post-sign smoke test runs after signing to catch Team ID mismatches that pre-sign tests miss.
+
+**Notarization** runs only on tag pushes (for example `v5.2.0`). Signing and build-time code signing run on `push` and `release` events within the `espressif` organization when all macOS signing credentials are provided. Pull request builds compile and test unsigned binaries; signing is skipped even if credentials are passed.
+
+If you use `macos-entitlements`, it is applied during both the PyInstaller build and the `release-sign` step.
 
 To enable signing, pass a base64-encoded Developer ID `.p12` certificate and related credentials from your workflow secrets:
 
@@ -320,22 +324,22 @@ jobs:
 
 This action uses the [espressif/release-sign](https://github.com/espressif/release-sign) action for signing. Signing is optional but strongly recommended. The action will produce a warning if a Windows or macOS executable was built but was not signed.
 
-| Input                      | Description                                 | Default | Example                                   |
-|----------------------------|---------------------------------------------|---------|-------------------------------------------|
-| **Windows**                |                                             |         |                                           |
-| `azure-client-id`          | Azure client ID for signing                 | `""`    | `${{ secrets.AZURE_CLIENT_ID }}`          |
-| `azure-client-secret`      | Azure client secret for signing             | `""`    | `${{ secrets.AZURE_CLIENT_SECRET }}`      |
-| `azure-tenant-id`          | Azure tenant ID for signing                 | `""`    | `${{ secrets.AZURE_TENANT_ID }}`          |
-| `azure-keyvault-uri`       | Azure key vault URI for signing             | `""`    | `${{ secrets.AZURE_KEYVAULT_URI }}`       |
-| `azure-keyvault-cert-name` | Azure key vault certificate name            | `""`    | `${{ secrets.AZURE_KEYVAULT_CERT_NAME }}` |
-| **macOS**                  |                                             |         |                                           |
-| `macos-signing-identity`   | Code signing identity                       | `""`    | `${{ secrets.MACOS_SIGNING_IDENTITY }}`   |
-| `macos-certificate`        | Base64-encoded .p12 certificate             | `""`    | `${{ secrets.MACOS_CERTIFICATE }}`        |
-| `macos-certificate-pwd`    | Password for .p12 certificate               | `""`    | `${{ secrets.MACOS_CERTIFICATE_PWD }}`    |
-| `macos-entitlements`       | Entitlements plist (optional)               | `""`    | `"./entitlements.plist"`                  |
-| `notarization-username`    | Apple ID for notarization (tag pushes only) | `""`    | `${{ secrets.NOTARIZATION_USERNAME }}`    |
-| `notarization-password`    | App-specific password (tag pushes only)     | `""`    | `${{ secrets.NOTARIZATION_PASSWORD }}`    |
-| `notarization-team-id`     | Apple Team ID (tag pushes only)             | `""`    | `${{ secrets.NOTARIZATION_TEAM_ID }}`     |
+| Input                      | Description                                    | Default | Example                                   |
+|----------------------------|------------------------------------------------|---------|-------------------------------------------|
+| **Windows**                |                                                |         |                                           |
+| `azure-client-id`          | Azure client ID for signing                    | `""`    | `${{ secrets.AZURE_CLIENT_ID }}`          |
+| `azure-client-secret`      | Azure client secret for signing                | `""`    | `${{ secrets.AZURE_CLIENT_SECRET }}`      |
+| `azure-tenant-id`          | Azure tenant ID for signing                    | `""`    | `${{ secrets.AZURE_TENANT_ID }}`          |
+| `azure-keyvault-uri`       | Azure key vault URI for signing                | `""`    | `${{ secrets.AZURE_KEYVAULT_URI }}`       |
+| `azure-keyvault-cert-name` | Azure key vault certificate name               | `""`    | `${{ secrets.AZURE_KEYVAULT_CERT_NAME }}` |
+| **macOS**                  |                                                |         |                                           |
+| `macos-signing-identity`   | Code signing identity                          | `""`    | `${{ secrets.MACOS_SIGNING_IDENTITY }}`   |
+| `macos-certificate`        | Base64-encoded .p12 certificate                | `""`    | `${{ secrets.MACOS_CERTIFICATE }}`        |
+| `macos-certificate-pwd`    | Password for .p12 certificate                  | `""`    | `${{ secrets.MACOS_CERTIFICATE_PWD }}`    |
+| `macos-entitlements`       | Entitlements plist - build and sign (optional) | `""`    | `"./entitlements.plist"`                  |
+| `notarization-username`    | Apple ID for notarization (tag pushes only)    | `""`    | `${{ secrets.NOTARIZATION_USERNAME }}`    |
+| `notarization-password`    | App-specific password (tag pushes only)        | `""`    | `${{ secrets.NOTARIZATION_PASSWORD }}`    |
+| `notarization-team-id`     | Apple Team ID (tag pushes only)                | `""`    | `${{ secrets.NOTARIZATION_TEAM_ID }}`     |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -95,7 +95,8 @@ inputs:
     required: false
     default: ''
   macos-entitlements:
-    description: Path to entitlements file for codesign (espressif/release-sign, optional)
+    description: Path to entitlements file for codesign during PyInstaller build and
+      espressif/release-sign (optional)
     required: false
     default: ''
   notarization-username:
@@ -273,11 +274,28 @@ runs:
           '${{ inputs.pip-extra-index-url }}' \
           '${{ inputs.install-deps-command }}'
 
+    - name: Setup macOS signing keychain
+      id: macos-signing-keychain
+      if: |
+        (inputs.target-platform == 'macos-amd64' || inputs.target-platform == 'macos-arm64') &&
+        inputs.macos-certificate != '' && inputs.macos-signing-identity != '' &&
+        inputs.macos-certificate-pwd != '' &&
+        (github.event_name == 'push' || github.event_name == 'release') && github.repository_owner == 'espressif'
+      shell: bash
+      env:
+        MACOS_SIGNING_IDENTITY: ${{ inputs.macos-signing-identity }}
+        MACOS_CERTIFICATE: ${{ inputs.macos-certificate }}
+        MACOS_CERTIFICATE_PWD: ${{ inputs.macos-certificate-pwd }}
+      run: bash $GITHUB_ACTION_PATH/setup_macos_signing_keychain.sh
+
     - name: Build with PyInstaller (Native platforms)
       if: |
         steps.setup-platform.outputs.needs-docker == 'false' && steps.setup-platform.outputs.needs-arm-emulation == 'false'
       id: build
       shell: bash
+      env:
+        MACOS_SIGNING_IDENTITY: ${{ steps.macos-signing-keychain.outcome == 'success' && inputs.macos-signing-identity || '' }}
+        MACOS_ENTITLEMENTS: ${{ steps.macos-signing-keychain.outcome == 'success' && inputs.macos-entitlements || '' }}
       run: |
         $GITHUB_ACTION_PATH/build_with_pyinstaller.sh '${{ inputs.target-platform }}' '${{ inputs.output-dir }}' '${{ inputs.scripts }}' '${{ inputs.script-name }}' '${{ inputs.icon-file }}' '${{ inputs.include-data-dirs }}' '${{ steps.setup-platform.outputs.data-separator }}' '${{ inputs.additional-args }}'
 
@@ -315,7 +333,9 @@ runs:
       if: |
         (
           (inputs.target-platform == 'windows-amd64' && inputs.azure-client-secret != '') ||
-          ((inputs.target-platform == 'macos-amd64' || inputs.target-platform == 'macos-arm64') && inputs.macos-certificate != '')
+          ((inputs.target-platform == 'macos-amd64' || inputs.target-platform == 'macos-arm64') &&
+            inputs.macos-certificate != '' && inputs.macos-signing-identity != '' &&
+            inputs.macos-certificate-pwd != '')
         ) &&
         (github.event_name == 'push' || github.event_name == 'release') && github.repository_owner == 'espressif'
       uses: espressif/release-sign@master
@@ -333,6 +353,21 @@ runs:
         notarization-username: ${{ github.ref_type == 'tag' && inputs.notarization-username || '' }}
         notarization-password: ${{ github.ref_type == 'tag' && inputs.notarization-password || '' }}
         notarization-team-id: ${{ github.ref_type == 'tag' && inputs.notarization-team-id || '' }}
+
+    - name: Verify signed builds
+      if: |
+        (inputs.target-platform == 'macos-amd64' || inputs.target-platform == 'macos-arm64') &&
+        inputs.macos-certificate != '' && inputs.macos-signing-identity != '' &&
+        inputs.macos-certificate-pwd != '' &&
+        (github.event_name == 'push' || github.event_name == 'release') && github.repository_owner == 'espressif'
+      shell: bash
+      run: |-
+        $GITHUB_ACTION_PATH/test_executables.sh \
+          "${{ inputs.scripts }}" \
+          "${{ inputs.script-name }}" \
+          "${{ inputs.output-dir }}" \
+          "${{ steps.setup-platform.outputs.exe-extension }}" \
+          "${{ inputs.test-command-args }}"
 
     - name: Remove leftover signature files
       if: |

--- a/build_with_pyinstaller.sh
+++ b/build_with_pyinstaller.sh
@@ -46,6 +46,16 @@ for i in "${!PYTHON_FILES[@]}"; do
     fi
   fi
 
+  # macOS: sign embedded libraries during collection (required for signed onefile binaries)
+  if [[ "$TARGET_PLATFORM" == macos-* ]] && [ -n "${MACOS_SIGNING_IDENTITY:-}" ]; then
+    identity_quoted=$(printf '%q' "$MACOS_SIGNING_IDENTITY")
+    cmd="$cmd --codesign-identity=$identity_quoted"
+    if [ -n "${MACOS_ENTITLEMENTS:-}" ] && [ -f "$MACOS_ENTITLEMENTS" ]; then
+      entitlements_quoted=$(printf '%q' "$MACOS_ENTITLEMENTS")
+      cmd="$cmd --osx-entitlements-file=$entitlements_quoted"
+    fi
+  fi
+
   # Add include-data-dirs using Python script
   if [ -n "$INCLUDE_DATA_DIRS" ]; then
     echo "Processing include-data-dirs for $file..."

--- a/setup_macos_signing_keychain.sh
+++ b/setup_macos_signing_keychain.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Import macOS Developer ID certificate into a temporary keychain for PyInstaller build-time signing.
+# Required env: MACOS_SIGNING_IDENTITY, MACOS_CERTIFICATE (base64 .p12), MACOS_CERTIFICATE_PWD.
+# The keychain persists for the remainder of the job (not deleted on exit).
+
+set -eu
+set +x
+
+: "${MACOS_SIGNING_IDENTITY:?macos-signing-identity required}"
+: "${MACOS_CERTIFICATE:?macos-certificate required}"
+: "${MACOS_CERTIFICATE_PWD:?macos-certificate-pwd required}"
+
+KEYCHAIN_NAME="pyinstaller-build.keychain"
+KEYCHAIN_PATH="${HOME}/Library/Keychains/${KEYCHAIN_NAME}-db"
+KEYCHAIN_PASSWORD=$(openssl rand -hex 32)
+CERT_PASSWORD=$(printf '%s' "$MACOS_CERTIFICATE_PWD" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+# Register values for GitHub Actions log redaction (also covers downstream steps in this job).
+echo "::add-mask::${MACOS_CERTIFICATE}"
+echo "::add-mask::${MACOS_CERTIFICATE_PWD}"
+echo "::add-mask::${CERT_PASSWORD}"
+echo "::add-mask::${KEYCHAIN_PASSWORD}"
+
+unset MACOS_CERTIFICATE_PWD
+
+CERT_FILE=$(mktemp)
+trap 'rm -f "$CERT_FILE"' EXIT
+
+echo "Setting up keychain for PyInstaller code signing..."
+security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_NAME" 2>/dev/null || true
+security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+_cert_b64=$(printf '%s' "$MACOS_CERTIFICATE" | tr -d ' \r\n\t')
+unset MACOS_CERTIFICATE
+if ! printf '%s' "$_cert_b64" | base64 --decode > "$CERT_FILE" 2>/dev/null; then
+  printf '%s' "$_cert_b64" | base64 -D > "$CERT_FILE" 2>/dev/null || {
+    echo "Error: macos-certificate could not be decoded. Use base64-encoded .p12 contents." >&2
+    exit 1
+  }
+fi
+unset _cert_b64
+[ -s "$CERT_FILE" ] || { echo "Error: decoded certificate is empty." >&2; exit 1; }
+
+if ! security import "$CERT_FILE" -f pkcs12 -k "$KEYCHAIN_PATH" -P "$CERT_PASSWORD" \
+  -T /usr/bin/codesign -T /usr/bin/security 2>/dev/null; then
+  echo "Error: Failed to import certificate into keychain." >&2
+  exit 1
+fi
+unset CERT_PASSWORD
+
+security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+unset KEYCHAIN_PASSWORD
+
+existing=$(security list-keychains -d user | sed 's/^[[:space:]]*"//;s/"[[:space:]]*$//' | tr '\n' ' ')
+# shellcheck disable=SC2086
+security list-keychains -d user -s "$KEYCHAIN_PATH" $existing
+security default-keychain -s "$KEYCHAIN_PATH"
+
+echo "Keychain ready for identity: $MACOS_SIGNING_IDENTITY"


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

PyInstaller `--onefile` has an issue with macOS signing where shared libraries bundled together with the binary have a different Team ID (https://github.com/pyinstaller/pyinstaller/issues/7937)

One solution to keep the `one-file` option is to sign everything before signing the outer binary


## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

- esptool build: https://github.com/espressif/esptool/actions/runs/26830101546
- local tests - thanks to reviewers!

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
